### PR TITLE
Add authentication methods

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,3 +43,7 @@ pluginBundle {
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
 }
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/VersionerPlugin.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/VersionerPlugin.kt
@@ -27,6 +27,7 @@ class VersionerPlugin : Plugin<Project> {
             tagVersionTask.startFrom = extension.startFrom
             tagVersionTask.match = extension.match
             tagVersionTask.tag = extension.tag
+            tagVersionTask.git = extension.git
             val version = versioner.version(extension.startFrom, extension.match)
             project.version = version
         }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Authentication.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Authentication.kt
@@ -1,0 +1,27 @@
+package io.toolebox.gradle.gitversioner.git
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+
+class Authentication(action: Action<Authentication>) {
+
+    var ssh = Ssh(Action { })
+
+    var https = Https(Action { })
+
+    init {
+        action.execute(this)
+    }
+
+    fun ssh(closure: Closure<Ssh>) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        closure.delegate = ssh
+        closure.call()
+    }
+
+    fun https(closure: Closure<Https>) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        closure.delegate = https
+        closure.call()
+    }
+}

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Git.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Git.kt
@@ -1,0 +1,20 @@
+package io.toolebox.gradle.gitversioner.git
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+
+class Git(action: Action<Git>) {
+
+    var authentication = Authentication(Action { })
+
+    init {
+        action.execute(this)
+    }
+
+    fun authentication(closure: Closure<Authentication>) {
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        closure.delegate = authentication
+        closure.call()
+    }
+
+}

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Https.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Https.kt
@@ -1,0 +1,16 @@
+package io.toolebox.gradle.gitversioner.git
+
+import groovy.lang.Closure
+import org.gradle.api.Action
+
+class Https(action: Action<Https>) {
+
+    var username: String? = null
+    var password: String? = null
+    var token: String? = null
+
+    init {
+        action.execute(this)
+    }
+
+}

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Ssh.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/git/Ssh.kt
@@ -1,0 +1,12 @@
+package io.toolebox.gradle.gitversioner.git
+
+import org.gradle.api.Action
+
+class Ssh(action: Action<Ssh>) {
+
+    var strictSsl = true
+
+    init {
+        action.execute(this)
+    }
+}

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/GitTagger.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/GitTagger.kt
@@ -1,17 +1,35 @@
 package io.toolebox.gradle.gitversioner.tag
 
+import com.jcraft.jsch.JSch
 import io.toolebox.gradle.gitversioner.configuration.Tag
 import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.transport.CredentialsProvider
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider
 import org.gradle.api.Project
 import java.io.File
 
 class GitTagger(private val project: Project) {
 
-    fun tag(version: String, tag: Tag) {
-        val git = Git.open(File("${project.rootDir}/.git"))
+    fun tag(version: String, tag: Tag, git: io.toolebox.gradle.gitversioner.tag.Git) {
+        var credentialsProvider = CredentialsProvider.getDefault()
+        if (git.authentication.ssh.strictSsl) {
+            JSch.setConfig("StrictHostKeyChecking", "yes");
+        } else {
+            JSch.setConfig("StrictHostKeyChecking", "no");
+        }
+        if (git.authentication.https.username != null) {
+            val username = git.authentication.https.username
+            val password = git.authentication.https.password
+            credentialsProvider = UsernamePasswordCredentialsProvider(username, password)
+        }
+        if (git.authentication.https.token != null) {
+            val username = git.authentication.https.token
+            credentialsProvider = UsernamePasswordCredentialsProvider(username, "")
+        }
+        val egit = Git.open(File("${project.rootDir}/.git"))
         val prefixedVersion = "${tag.prefix}$version"
-        git.tag().setName(prefixedVersion).call()
-        git.push().add(prefixedVersion).call()
+        egit.tag().setName(prefixedVersion).call()
+        egit.push().add(prefixedVersion).setCredentialsProvider(credentialsProvider).call()
     }
 
 }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/TagVersionTask.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/TagVersionTask.kt
@@ -3,6 +3,7 @@ package io.toolebox.gradle.gitversioner.tag
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import io.toolebox.gradle.gitversioner.configuration.Tag
+import io.toolebox.gradle.gitversioner.git.Git
 import io.toolebox.gradle.gitversioner.version.Versioner
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
@@ -19,10 +20,12 @@ open class TagVersionTask : DefaultTask() {
     lateinit var match: Match
     @Input
     lateinit var tag: Tag
+    @Input
+    lateinit var git: Git
 
     @TaskAction
     fun tagVersion() {
         val version = versioner.version(startFrom, match)
-        tagger.tag(version, tag)
+        tagger.tag(version, tag, git)
     }
 }


### PR DESCRIPTION
This adds authentication for SSH and HTTPS.

SSH should work anyway, but currently JGit only supports RSA keys
for known hosts, and will fail for ecdsa keys. The only real
workaround for now is to disable the strict host checking for
ecdsa keys if you can't use RSA.

HTTPS is a bit easier. You can use username, password, and token.
Username and password work as expected and pass along the
credentials with the request. Token probably isn't the best
implementation it could be- it's been built with GitHub in mind,
so it will pass the token in as the username for the request. This
might not work for other platforms though. I don't have that use
case right now though so we can just wait for an issue to be raised
with that specific requirement and implement it then.