### PR TITLE
Added ability to toggle maven snapshot on version when regular commits are greater than zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ This is really not the best idea for large or established projects, as you're go
 
 If you still want to do it, just go for a `git rebase -i <yourFirstCommit>`, mark any of the commits where you've updated the version to be reworded, then one-by-one update the commit messages to include either [major], [minor], or [patch]. If you've done it right, the version produced by Git Versioner will be the same as your current version. Pretty neat right?
 
+### I'm using Maven SNAPSHOT's
+You still can! Simply specify the following configuration:
+```
+versioner {
+  mavenSnapshotQualifier {
+    enabled = true
+  }
+}
+```
+
+When you next make a regular commit (not a major/minor/patch), the version will be appended with `-SNAPSHOT`, rather than the patch or build revision (e.g. `1.2-SNAPSHOT`). Once you commit a major/minor/patch message, it will correctly replace `-SNAPSHOT` with the correct value (e.g. `1.2.3`).
+
+It also works with Git tags, but do you really want to tag something in Git with `-SNAPSHOT`? It's recommended that you only use this for development, and not actual releases.
+
+If you want more information about Maven SNAPSHOT, click [Maven - Maven Getting Started: What is a SNAPSHOT version?](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version)
+
 ## Can I tag things in git so I know what version I'm on?
 Yes! So originally we would have recommended you do it yourself by running something like
 `./gradlew -q printVersion || xargs git tag && git push --tags`, which if the syntax is correct I think will probably

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ If you still want to do it, just go for a `git rebase -i <yourFirstCommit>`, mar
 You still can! Simply specify the following configuration:
 ```
 versioner {
-  mavenSnapshotQualifier {
-    enabled = true
+  mavenSnapshot {
+    enabled = true  // defaults to false
   }
 }
 ```
@@ -74,7 +74,7 @@ When you next make a regular commit (not a major/minor/patch), the version will 
 
 It also works with Git tags, but do you really want to tag something in Git with `-SNAPSHOT`? It's recommended that you only use this for development, and not actual releases.
 
-If you want more information about Maven SNAPSHOT, click [Maven - Maven Getting Started: What is a SNAPSHOT version?](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version)
+If you want more information about Maven SNAPSHOT, click [Maven - Maven Getting Started Guide: What is a SNAPSHOT version?](https://maven.apache.org/guides/getting-started/index.html#What_is_a_SNAPSHOT_version)
 
 ## Can I tag things in git so I know what version I'm on?
 Yes! So originally we would have recommended you do it yourself by running something like

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/VersionerPlugin.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/VersionerPlugin.kt
@@ -24,11 +24,13 @@ class VersionerPlugin : Plugin<Project> {
         project.afterEvaluate {
             printVersionTask.startFrom = extension.startFrom
             printVersionTask.match = extension.match
+            printVersionTask.mavenSnapshotQualifier = extension.mavenSnapshotQualifier
             tagVersionTask.startFrom = extension.startFrom
             tagVersionTask.match = extension.match
+            tagVersionTask.mavenSnapshotQualifier = extension.mavenSnapshotQualifier
             tagVersionTask.tag = extension.tag
             tagVersionTask.git = extension.git
-            val version = versioner.version(extension.startFrom, extension.match)
+            val version = versioner.version(extension.startFrom, extension.mavenSnapshotQualifier, extension.match)
             project.version = version
         }
     }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/VersionerPlugin.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/VersionerPlugin.kt
@@ -24,13 +24,13 @@ class VersionerPlugin : Plugin<Project> {
         project.afterEvaluate {
             printVersionTask.startFrom = extension.startFrom
             printVersionTask.match = extension.match
-            printVersionTask.mavenSnapshotQualifier = extension.mavenSnapshotQualifier
+            printVersionTask.mavenSnapshot = extension.mavenSnapshot
             tagVersionTask.startFrom = extension.startFrom
             tagVersionTask.match = extension.match
-            tagVersionTask.mavenSnapshotQualifier = extension.mavenSnapshotQualifier
+            tagVersionTask.mavenSnapshot = extension.mavenSnapshot
             tagVersionTask.tag = extension.tag
             tagVersionTask.git = extension.git
-            val version = versioner.version(extension.startFrom, extension.mavenSnapshotQualifier, extension.match)
+            val version = versioner.version(extension.startFrom, extension.mavenSnapshot, extension.match)
             project.version = version
         }
     }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/MavenSnapshot.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/MavenSnapshot.kt
@@ -2,7 +2,7 @@ package io.toolebox.gradle.gitversioner.configuration
 
 import org.gradle.api.Action
 
-class MavenSnapshotQualifier(action: Action<MavenSnapshotQualifier>) {
+class MavenSnapshot(action: Action<MavenSnapshot>) {
 
     var enabled = false
 

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/MavenSnapshotStyle.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/MavenSnapshotStyle.kt
@@ -1,0 +1,12 @@
+package io.toolebox.gradle.gitversioner.configuration
+
+import org.gradle.api.Action
+
+class MavenSnapshotQualifier(action: Action<MavenSnapshotQualifier>) {
+
+    var enabled = false
+
+    init {
+        action.execute(this)
+    }
+}

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/VersionerPluginExtension.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/VersionerPluginExtension.kt
@@ -7,6 +7,8 @@ open class VersionerPluginExtension {
 
     var startFrom = StartFrom(Action { })
 
+    var mavenSnapshotQualifier = MavenSnapshotQualifier(Action { })
+
     var match = Match(Action { })
 
     var tag = Tag(Action { })
@@ -15,6 +17,10 @@ open class VersionerPluginExtension {
 
     fun startFrom(action: Action<StartFrom>) {
         startFrom = StartFrom(action)
+    }
+
+    fun mavenSnapshotQualifier(action: Action<MavenSnapshotQualifier>) {
+        mavenSnapshotQualifier = MavenSnapshotQualifier(action)
     }
 
     fun match(action: Action<Match>) {

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/VersionerPluginExtension.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/configuration/VersionerPluginExtension.kt
@@ -7,7 +7,7 @@ open class VersionerPluginExtension {
 
     var startFrom = StartFrom(Action { })
 
-    var mavenSnapshotQualifier = MavenSnapshotQualifier(Action { })
+    var mavenSnapshot = MavenSnapshot(Action { })
 
     var match = Match(Action { })
 
@@ -19,8 +19,8 @@ open class VersionerPluginExtension {
         startFrom = StartFrom(action)
     }
 
-    fun mavenSnapshotQualifier(action: Action<MavenSnapshotQualifier>) {
-        mavenSnapshotQualifier = MavenSnapshotQualifier(action)
+    fun mavenSnapshot(action: Action<MavenSnapshot>) {
+        mavenSnapshot = MavenSnapshot(action)
     }
 
     fun match(action: Action<Match>) {

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/TagVersionTask.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/TagVersionTask.kt
@@ -1,5 +1,6 @@
 package io.toolebox.gradle.gitversioner.tag
 
+import io.toolebox.gradle.gitversioner.configuration.MavenSnapshotQualifier
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import io.toolebox.gradle.gitversioner.configuration.Tag
@@ -17,6 +18,8 @@ open class TagVersionTask : DefaultTask() {
     @Input
     lateinit var startFrom: StartFrom
     @Input
+    lateinit var mavenSnapshotQualifier: MavenSnapshotQualifier
+    @Input
     lateinit var match: Match
     @Input
     lateinit var tag: Tag
@@ -25,7 +28,7 @@ open class TagVersionTask : DefaultTask() {
 
     @TaskAction
     fun tagVersion() {
-        val version = versioner.version(startFrom, match)
+        val version = versioner.version(startFrom, mavenSnapshotQualifier, match)
         tagger.tag(version, tag, git)
     }
 }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/TagVersionTask.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/tag/TagVersionTask.kt
@@ -1,6 +1,6 @@
 package io.toolebox.gradle.gitversioner.tag
 
-import io.toolebox.gradle.gitversioner.configuration.MavenSnapshotQualifier
+import io.toolebox.gradle.gitversioner.configuration.MavenSnapshot
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import io.toolebox.gradle.gitversioner.configuration.Tag
@@ -18,7 +18,7 @@ open class TagVersionTask : DefaultTask() {
     @Input
     lateinit var startFrom: StartFrom
     @Input
-    lateinit var mavenSnapshotQualifier: MavenSnapshotQualifier
+    lateinit var mavenSnapshot: MavenSnapshot
     @Input
     lateinit var match: Match
     @Input
@@ -28,7 +28,7 @@ open class TagVersionTask : DefaultTask() {
 
     @TaskAction
     fun tagVersion() {
-        val version = versioner.version(startFrom, mavenSnapshotQualifier, match)
+        val version = versioner.version(startFrom, mavenSnapshot, match)
         tagger.tag(version, tag, git)
     }
 }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/version/PrintVersionTask.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/version/PrintVersionTask.kt
@@ -1,5 +1,6 @@
 package io.toolebox.gradle.gitversioner.version
 
+import io.toolebox.gradle.gitversioner.configuration.MavenSnapshotQualifier
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import org.gradle.api.DefaultTask
@@ -12,10 +13,12 @@ open class PrintVersionTask : DefaultTask() {
     @Input
     lateinit var startFrom: StartFrom
     @Input
+    lateinit var mavenSnapshotQualifier: MavenSnapshotQualifier
+    @Input
     lateinit var match: Match
 
     @TaskAction
     fun printVersion() {
-        println(versioner.version(startFrom, match))
+        println(versioner.version(startFrom, mavenSnapshotQualifier, match))
     }
 }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/version/PrintVersionTask.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/version/PrintVersionTask.kt
@@ -1,6 +1,6 @@
 package io.toolebox.gradle.gitversioner.version
 
-import io.toolebox.gradle.gitversioner.configuration.MavenSnapshotQualifier
+import io.toolebox.gradle.gitversioner.configuration.MavenSnapshot
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import org.gradle.api.DefaultTask
@@ -13,12 +13,12 @@ open class PrintVersionTask : DefaultTask() {
     @Input
     lateinit var startFrom: StartFrom
     @Input
-    lateinit var mavenSnapshotQualifier: MavenSnapshotQualifier
+    lateinit var mavenSnapshot: MavenSnapshot
     @Input
     lateinit var match: Match
 
     @TaskAction
     fun printVersion() {
-        println(versioner.version(startFrom, mavenSnapshotQualifier, match))
+        println(versioner.version(startFrom, mavenSnapshot, match))
     }
 }

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/version/Versioner.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/version/Versioner.kt
@@ -1,6 +1,6 @@
 package io.toolebox.gradle.gitversioner.version
 
-import io.toolebox.gradle.gitversioner.configuration.MavenSnapshotQualifier
+import io.toolebox.gradle.gitversioner.configuration.MavenSnapshot
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import org.eclipse.jgit.api.Git
@@ -9,7 +9,7 @@ import java.io.File
 
 class Versioner(private val project: Project) {
 
-    fun version(startFrom: StartFrom, mavenSnapshotQualifier: MavenSnapshotQualifier, match: Match): String {
+    fun version(startFrom: StartFrom, mavenSnapshot: MavenSnapshot, match: Match): String {
         var major = startFrom.major
         var minor = startFrom.minor
         var patch = startFrom.patch
@@ -38,7 +38,7 @@ class Versioner(private val project: Project) {
             }
         }
 
-        if (mavenSnapshotQualifier.enabled) {
+        if (mavenSnapshot.enabled) {
             return "$major.$minor${if (build == 0) ".$patch" else "-SNAPSHOT"}"
         } else {
             return "$major.$minor.$patch${if (build == 0) "" else ".$build"}"

--- a/src/main/kotlin/io/toolebox/gradle/gitversioner/version/Versioner.kt
+++ b/src/main/kotlin/io/toolebox/gradle/gitversioner/version/Versioner.kt
@@ -1,5 +1,6 @@
 package io.toolebox.gradle.gitversioner.version
 
+import io.toolebox.gradle.gitversioner.configuration.MavenSnapshotQualifier
 import io.toolebox.gradle.gitversioner.configuration.Match
 import io.toolebox.gradle.gitversioner.configuration.StartFrom
 import org.eclipse.jgit.api.Git
@@ -8,7 +9,7 @@ import java.io.File
 
 class Versioner(private val project: Project) {
 
-    fun version(startFrom: StartFrom, match: Match): String {
+    fun version(startFrom: StartFrom, mavenSnapshotQualifier: MavenSnapshotQualifier, match: Match): String {
         var major = startFrom.major
         var minor = startFrom.minor
         var patch = startFrom.patch
@@ -36,7 +37,12 @@ class Versioner(private val project: Project) {
                 else -> build++
             }
         }
-        return "$major.$minor.$patch${if (build == 0) "" else ".$build"}"
+
+        if (mavenSnapshotQualifier.enabled) {
+            return "$major.$minor${if (build == 0) ".$patch" else "-SNAPSHOT"}"
+        } else {
+            return "$major.$minor.$patch${if (build == 0) "" else ".$build"}"
+        }
     }
 
 }

--- a/src/test/kotlin/io/toolebox/gradle/gitversioner/tag/GitTaggerSpec.kt
+++ b/src/test/kotlin/io/toolebox/gradle/gitversioner/tag/GitTaggerSpec.kt
@@ -37,7 +37,7 @@ class GitTaggerSpec : FreeSpec() {
                 }
                 assertThat(output.toString()).isEqualToIgnoringNewLines("v0.0.0.3")
             }
-            "Creates tag with specified prefix when configured" {
+            "Creates tag with specified snapshot prefix when configured" {
                 givenWeHaveLocalAndRemoteRepositories()
                 givenProjectIsUsingCustomConfiguration()
                 givenRepositoryHasRegularCommitsNumbering(3)
@@ -51,7 +51,7 @@ class GitTaggerSpec : FreeSpec() {
                     it.commandLine("git")
                     it.args("tag")
                 }
-                assertThat(output.toString()).isEqualToIgnoringNewLines("x1.1.1.3")
+                assertThat(output.toString()).isEqualToIgnoringNewLines("x1.1-SNAPSHOT")
             }
         }
     }

--- a/src/test/kotlin/io/toolebox/gradle/gitversioner/version/VersionerSpec.kt
+++ b/src/test/kotlin/io/toolebox/gradle/gitversioner/version/VersionerSpec.kt
@@ -143,6 +143,41 @@ class VersionerPluginTest : FreeSpec() {
 
                 assertThat(result.output).isEqualToIgnoringNewLines("1.1.4")
             }
+            "Appends SNAPSHOT when regular commits are not zero" {
+                givenProjectIsUsingCustomConfiguration()
+                givenProjectContainsGitRepository()
+                givenRepositoryHasMajorCommitsNumbering(1)
+                givenRepositoryHasRegularCommitsNumbering(1)
+
+                val result = runTask()
+
+                assertThat(result.output).isEqualToIgnoringNewLines("2.0-SNAPSHOT")
+            }
+            "Appends SNAPSHOT with many commits" {
+                givenProjectIsUsingCustomConfiguration()
+                givenProjectContainsGitRepository()
+                givenRepositoryHasMajorCommitsNumbering(1)
+                givenRepositoryHasMinorCommitsNumbering(13)
+                givenRepositoryHasPatchCommitsNumbering(10)
+                givenRepositoryHasRegularCommitsNumbering(10)
+
+                val result = runTask()
+
+                assertThat(result.output).isEqualToIgnoringNewLines("2.13-SNAPSHOT")
+            }
+            "Does not append SNAPSHOT with many commits after final major" {
+                givenProjectIsUsingCustomConfiguration()
+                givenProjectContainsGitRepository()
+                givenRepositoryHasMajorCommitsNumbering(1)
+                givenRepositoryHasMinorCommitsNumbering(13)
+                givenRepositoryHasPatchCommitsNumbering(10)
+                givenRepositoryHasRegularCommitsNumbering(10)
+                givenRepositoryHasMajorCommitsNumbering(1)
+
+                val result = runTask()
+
+                assertThat(result.output).isEqualToIgnoringNewLines("3.0.0")
+            }
         }
     }
 

--- a/src/test/resources/configured-build.gradle
+++ b/src/test/resources/configured-build.gradle
@@ -8,7 +8,7 @@ versioner {
         minor = 1
         patch = 1
     }
-    mavenSnapshotQualifier {
+    mavenSnapshot {
         enabled = true
     }
     match {

--- a/src/test/resources/configured-build.gradle
+++ b/src/test/resources/configured-build.gradle
@@ -8,6 +8,9 @@ versioner {
         minor = 1
         patch = 1
     }
+    mavenSnapshotQualifier {
+        enabled = true
+    }
     match {
         major = "major"
         minor = "minor"


### PR DESCRIPTION
In reference to #4 , this PR adds the ability to toggle maven snapshots on the generated version. I've updated tests and such, though I think that the method of specifying the configuration could be refactored into a more robust class, rather than being scattered into three or four already.

I'm not a pro with Kotlin by any standards, so any guidance or things I've missed please let me know.